### PR TITLE
add wildcards to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.idea
-.DS_Store
+**/.idea
+**/.DS_Store


### PR DESCRIPTION
~~that way it looks into subdirectories too, not just the root, which is presumably what you'd want when starting new julia projects~~ EDIT: check last comment, am dumdum

> two consecutive asterisks ("\*\*") in patterns matched against full pathname may have special meaning:
> 
> - A leading "\*\*" followed by a slash means match in all directories. For example, "\*\*/foo" matches file or directory "foo" anywhere, the same as pattern "foo". "\*\*/foo/bar" matches file or directory "bar" anywhere that is directly under directory "foo".
(https://git-scm.com/docs/gitignore)
